### PR TITLE
fix dependencies for romeo_description

### DIFF
--- a/romeo_description/CMakeLists.txt
+++ b/romeo_description/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
 )
 
 # Nothing that can be imported by other modules
-catkin_package(CATKIN_DEPENDS roscpp tf message_filter sensor_msgs)
+catkin_package(CATKIN_DEPENDS roscpp tf message_filters sensor_msgs)
 
 catkin_python_setup()
 

--- a/romeo_description/package.xml
+++ b/romeo_description/package.xml
@@ -41,6 +41,14 @@
   <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
 
+  <build_depend>message_filters</build_depend>
+  <build_depend>roscpp</build_depend>
+  <build_depend>sensor_msgs</build_depend>
+  <build_depend>tf</build_depend>
+  <run_depend>message_filters</run_depend>
+  <run_depend>roscpp</run_depend>
+  <run_depend>sensor_msgs</run_depend>
+  <run_depend>tf</run_depend>
 
   <!-- The export tag contains other, unspecified, tags -->
   <export>


### PR DESCRIPTION
Looks like you're missing quite a few deps.

Example build failure: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-romeo-description_binaryrpm_heisenbug_x86_64/3/console

Thanks,

--scott
