### PR TITLE
Call catkin_package() in romeo_sensors

### DIFF
--- a/romeo_sensors/CMakeLists.txt
+++ b/romeo_sensors/CMakeLists.txt
@@ -9,6 +9,11 @@ find_package(catkin REQUIRED COMPONENTS
   rospy
 )
 
+catkin_package(CATKIN_DEPENDS
+  roscpp
+  rospy
+)
+
 # Instructions to install launch files
 install(DIRECTORY launch/
     DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}/launch


### PR DESCRIPTION
If you don't call `catkin_package()`, `${CATKIN_PACKAGE_SHARE_DESTINATION}` never gets set. This results in your files getting installed to the system root partition (`/`) instead of `/opt/ros/indigo/share/romeo_sensors`.

This is a major packaging bug.

Example of breakage: http://csc.mcs.sdsmt.edu/jenkins/job/ros-indigo-romeo-sensors_binaryrpm_heisenbug_x86_64/1/console

Thanks,

--scott
