### PR TITLE
Description Launch File Typo

### DIFF
--- a/romeo_description/launch/display_generated.launch
+++ b/romeo_description/launch/display_generated.launch
@@ -4,8 +4,8 @@
 	<arg name="model" />
 	<arg name="gui" default="True" />
 
-  <include file="$(find romeo_description)/launch/romeo_desc_generated.launch">
+  <include file="$(find romeo_description)/launch/romeo_desc_generated.launch"/>
 	<param name="use_gui" value="$(arg gui)"/>
-	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" ></node>
+	<node name="joint_state_publisher" pkg="joint_state_publisher" type="joint_state_publisher" />
 	<node name="rviz" pkg="rviz" type="rviz" args="-f torso -d $(find romeo_description)/config/urdf.rviz" />
 </launch>


### PR DESCRIPTION
Hey,

The ```<include>``` tag was not closed in the ```romeo_description/launch/display_generated.launch``` file.

I fixed the problem and it is working now. Below is the screen shot.

Thanks.

![image](https://user-images.githubusercontent.com/8410351/44671295-71873b80-aa25-11e8-89f6-f54c61e0c909.png)
